### PR TITLE
Add table_name_prefix support

### DIFF
--- a/db/migrate/004_convert_next_issues_to_stuff_to_dos.rb
+++ b/db/migrate/004_convert_next_issues_to_stuff_to_dos.rb
@@ -1,6 +1,8 @@
 # Compatibiliy class used by migrations
 class NextIssue < ActiveRecord::Base
-  set_table_name 'next_issues'
+  set_table_name do
+    "#{table_name_prefix}next_issues"
+  end
 end
 
 class ConvertNextIssuesToStuffToDos < ActiveRecord::Migration

--- a/lib/stuff_to_do_issue_patch.rb
+++ b/lib/stuff_to_do_issue_patch.rb
@@ -11,7 +11,7 @@ module StuffToDoIssuePatch
 
       after_save :update_next_issues
       has_many :stuff_to_dos, :as => :stuff
-      has_and_belongs_to_many :time_grid_users, :class_name => 'User', :join_table => 'time_grid_issues_users'
+      has_and_belongs_to_many :time_grid_users, :class_name => 'User', :join_table => "#{table_name_prefix}time_grid_issues_users"
 
       named_scope :with_time_entries_for_user, lambda {|user_id|
         {

--- a/lib/stuff_to_do_user_patch.rb
+++ b/lib/stuff_to_do_user_patch.rb
@@ -3,7 +3,7 @@ module StuffToDoUserPatch
   def self.included(base) # :nodoc:
     base.class_eval do
       unloadable
-      has_and_belongs_to_many :time_grid_issues, :class_name => 'Issue', :join_table => 'time_grid_issues_users'
+      has_and_belongs_to_many :time_grid_issues, :class_name => 'Issue', :join_table => "#{table_name_prefix}time_grid_issues_users"
     end
   end
 end


### PR DESCRIPTION
This allows the plugin to be used on Redmine installations that have the ActiveRecord `table_name_prefix` option set.
